### PR TITLE
Support for in-container Java experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ tags
 target
 coverage.txt
 vendor
+/build/cache
 
 # Website
 site-build

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GO=env $(GO_ENV) $(GO_MODULE) go
 UNAME := $(shell uname)
 
 ifeq ($(BLADE_VERSION), )
-	BLADE_VERSION=1.4.0
+	BLADE_VERSION=1.5.0
 endif
 
 BUILD_TARGET=target
@@ -18,6 +18,8 @@ BUILD_IMAGE_PATH=build/image/blade
 
 OS_YAML_FILE_NAME=chaosblade-cri-spec-$(BLADE_VERSION).yaml
 OS_YAML_FILE_PATH=$(BUILD_TARGET_YAML)/$(OS_YAML_FILE_NAME)
+
+CHAOSBLADE_PATH=build/cache/chaosblade
 
 ifeq ($(GOOS), linux)
 	GO_FLAGS=-ldflags="-linkmode external -extldflags -static"
@@ -32,7 +34,7 @@ pre_build:
 	mkdir -p $(BUILD_TARGET_YAML)
 
 build_yaml: build/spec.go
-	$(GO) run $< $(OS_YAML_FILE_PATH)
+	$(GO) run $< $(OS_YAML_FILE_PATH) $(CHAOSBLADE_PATH)/yaml/chaosblade-jvm-spec-$(BLADE_VERSION).yaml
 
 # test
 test:

--- a/build/spec.go
+++ b/build/spec.go
@@ -28,8 +28,11 @@ import (
 
 // main creates a yaml file of the experiments in the project
 func main() {
-	if len(os.Args) != 2 {
+	if len(os.Args) < 2 {
 		log.Panicln("less yaml file path")
+	}
+	if len(os.Args) == 3 {
+		exec.JvmSpecFileForYaml = os.Args[2]
 	}
 	err := util.CreateYamlFile(getModels(), os.Args[1])
 	if err != nil {

--- a/exec/application.go
+++ b/exec/application.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package exec
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+
+	"github.com/chaosblade-io/chaosblade-exec-cri/version"
+)
+
+var JvmSpecFileForYaml = ""
+
+// getJvmModels returns java experiment specs
+func getJvmModels() []spec.ExpModelCommandSpec {
+	var jvmSpecFile = path.Join(util.GetYamlHome(), fmt.Sprintf("chaosblade-jvm-spec-%s.yaml", version.BladeVersion))
+	if JvmSpecFileForYaml != "" {
+		jvmSpecFile = JvmSpecFileForYaml
+	}
+	modelCommandSpecs := make([]spec.ExpModelCommandSpec, 0)
+	models, err := util.ParseSpecsToModel(jvmSpecFile, nil)
+	if err != nil {
+		logrus.Warningf("parse java spec failed, so skip it, %s", err)
+		return modelCommandSpecs
+	}
+	for idx := range models.Models {
+		modelCommandSpecs = append(modelCommandSpecs, &models.Models[idx])
+	}
+	return modelCommandSpecs
+}

--- a/exec/model.go
+++ b/exec/model.go
@@ -42,6 +42,7 @@ func NewCriExpModelSpec() *dockerExpModelSpec {
 		networkCommandModelSpec,
 	}
 
+	javaExpModelSpecs := getJvmModels()
 	execInContainerModelSpecs := []spec.ExpModelCommandSpec{
 		newProcessCommandModelSpecForDocker(),
 		newCpuCommandModelSpecForDocker(),
@@ -49,6 +50,7 @@ func NewCriExpModelSpec() *dockerExpModelSpec {
 		newMemCommandModelSpecForDocker(),
 		newFileCommandSpecForDocker(),
 	}
+	execInContainerModelSpecs = append(execInContainerModelSpecs, javaExpModelSpecs...)
 	containerSelfModelSpec := NewContainerCommandSpec()
 
 	spec.AddExecutorToModelSpec(NewNetWorkSidecarExecutor(), networkCommandModelSpec)

--- a/version/version.go
+++ b/version/version.go
@@ -17,4 +17,4 @@
 package version
 
 // Default version is latest, you can specify the value at compile time, see Makefile in chaosblade project for the details
-var BladeVersion = "latest"
+var BladeVersion = "1.5.0"


### PR DESCRIPTION
Signed-off-by: xcaspar <changjun.xcj@alibaba-inc.com>

### Describe what this PR does / why we need it
chaosblade-io/chaosblade#437

### Describe how you did it

### Describe how to verify it
Package and test it.

Examples of using jvm process CPU full load, the command is as follows:
```
blade create cri jvm cpufullload --pid 1 --container-id e070422d5638 --chaosblade-release ~/chaosblade-1.5.0.tar.gz
```

![image](https://user-images.githubusercontent.com/3992234/146316673-51dbb37b-2ea9-46f2-bca3-69b76a1f7f5a.png)

![image](https://user-images.githubusercontent.com/3992234/146316687-d390ce52-8a3e-47bd-aa89-2c046ee8af0a.png)


### Special notes for reviews


