### PR TITLE
add container-label-selector flag for container selection

### DIFF
--- a/exec/container.go
+++ b/exec/container.go
@@ -118,7 +118,8 @@ func (e *removeActionExecutor) Exec(uid string, ctx context.Context, model *spec
 	}
 	containerId := flags[ContainerIdFlag.Name]
 	containerName := flags[ContainerNameFlag.Name]
-	container, response := GetContainer(client, uid, containerId, containerName)
+	containerLabelSelector := parseContainerLabelSelector(flags[ContainerNameFlag.Name])
+	container, response := GetContainer(client, uid, containerId, containerName, containerLabelSelector)
 	if !response.Success {
 		return response
 	}

--- a/exec/container/container.go
+++ b/exec/container/container.go
@@ -37,6 +37,7 @@ const (
 type Container interface {
 	GetContainerById(containerId string) (ContainerInfo, error, int32)
 	GetContainerByName(containerName string) (ContainerInfo, error, int32)
+	GetContainerByLabelSelector(containerLabelSelector map[string]string) (ContainerInfo, error, int32)
 	RemoveContainer(containerId string, force bool) error
 	CopyToContainer(containerId, srcFile, dstPath, extractDirName string, override bool) error
 

--- a/exec/container/containerd/containerd.go
+++ b/exec/container/containerd/containerd.go
@@ -133,6 +133,21 @@ func (c *Client) GetContainerByName(containerName string) (container.ContainerIn
 	return convertContainerInfo(containerDetails[0]), nil, spec.OK.Code
 }
 
+func (c *Client) GetContainerByLabelSelector(labels map[string]string) (container.ContainerInfo, error, int32) {
+	filters := make([]string, 0)
+
+	for k, v := range labels {
+		filters = append(filters, fmt.Sprintf(`labels."%s"==%s`, k, v))
+	}
+
+	containerDetails, err := c.cclient.ContainerService().List(c.Ctx, strings.Join(filters, ","))
+	if err != nil {
+		return container.ContainerInfo{}, err, spec.ContainerExecFailed.Code
+	}
+
+	return convertContainerInfo(containerDetails[0]), nil, spec.OK.Code
+}
+
 func convertContainerInfo(containerDetail containers.Container) container.ContainerInfo {
 	return container.ContainerInfo{
 		ContainerId:   containerDetail.ID,

--- a/exec/container/docker/docker.go
+++ b/exec/container/docker/docker.go
@@ -125,6 +125,19 @@ func (c *Client) GetContainerByName(containerName string) (container.ContainerIn
 
 }
 
+func (c *Client) GetContainerByLabelSelector(labels map[string]string) (container.ContainerInfo, error, int32) {
+	args := make([]filters.KeyValuePair, 0)
+
+	for k, v := range labels {
+		args = append(args, filters.Arg("label", fmt.Sprintf("%s=%s", k, v)))
+	}
+
+	return c.GetContainerFromDocker(types.ContainerListOptions{
+		All:     true,
+		Filters: filters.NewArgs(args...),
+	})
+}
+
 func (c *Client) GetContainerFromDocker(option types.ContainerListOptions) (container.ContainerInfo, error, int32) {
 	containers, err := c.client.ContainerList(context.Background(), option)
 

--- a/exec/executor_execin.go
+++ b/exec/executor_execin.go
@@ -62,7 +62,8 @@ func (r *RunCmdInContainerExecutorByCP) Exec(uid string, ctx context.Context, ex
 	}
 	containerId := expModel.ActionFlags[ContainerIdFlag.Name]
 	containerName := expModel.ActionFlags[ContainerNameFlag.Name]
-	container, response := GetContainer(r.Client, uid, containerId, containerName)
+	containerLabelSelector := parseContainerLabelSelector(expModel.ActionFlags[ContainerNameFlag.Name])
+	container, response := GetContainer(r.Client, uid, containerId, containerName, containerLabelSelector)
 	if !response.Success {
 		return response
 	}

--- a/exec/executor_sidecar.go
+++ b/exec/executor_sidecar.go
@@ -48,7 +48,8 @@ func (r *RunInSidecarContainerExecutor) Exec(uid string, ctx context.Context, ex
 	}
 	containerId := expModel.ActionFlags[ContainerIdFlag.Name]
 	containerName := expModel.ActionFlags[ContainerNameFlag.Name]
-	containerInfo, response := GetContainer(r.Client, uid, containerId, containerName)
+	containerLabelSelector := parseContainerLabelSelector(expModel.ActionFlags[ContainerLabelSelectorFlag.Name])
+	containerInfo, response := GetContainer(r.Client, uid, containerId, containerName, containerLabelSelector)
 	if !response.Success {
 		return response
 	}

--- a/exec/model.go
+++ b/exec/model.go
@@ -379,6 +379,14 @@ var ContainerNameFlag = &spec.ExpFlag{
 	RequiredWhenDestroyed: false,
 }
 
+var ContainerLabelSelectorFlag = &spec.ExpFlag{
+	Name:                  "container-label-selector",
+	Desc:                  "Container label selector, when used with container-id or container-name, container-id or container-name is preferred",
+	NoArgs:                false,
+	Required:              false,
+	RequiredWhenDestroyed: false,
+}
+
 var ImageRepoFlag = &spec.ExpFlag{
 	Name:     "image-repo",
 	Desc:     "Image repository of the chaosblade-tool",
@@ -439,6 +447,7 @@ func GetExecSidecarFlags() []spec.ExpFlagSpec {
 	return []spec.ExpFlagSpec{
 		ContainerIdFlag,
 		ContainerNameFlag,
+		ContainerLabelSelectorFlag,
 		ImageRepoFlag,
 		ImageVersionFlag,
 		EndpointFlag,
@@ -461,9 +470,28 @@ func GetExecInContainerFlags() []spec.ExpFlagSpec {
 	}
 }
 
+func getAllDockerFlags() []spec.ExpFlagSpec {
+	allFlags := make([]spec.ExpFlagSpec, 0)
+	allFlags = append(allFlags, GetContainerSelfFlags()...)
+	allFlags = append(allFlags, GetExecSidecarFlags()...)
+	allFlags = append(allFlags, GetExecInContainerFlags()...)
+
+	set := make(map[spec.ExpFlagSpec]bool, 0)
+	flags := make([]spec.ExpFlagSpec, 0)
+
+	for i := range allFlags {
+		if !set[allFlags[i]] {
+			flags = append(flags, allFlags[i])
+			set[allFlags[i]] = true
+		}
+	}
+
+	return flags
+}
+
 func GetAllDockerFlagNames() map[string]spec.Empty {
 	flagNames := make(map[string]spec.Empty, 0)
-	for _, flag := range GetExecInContainerFlags() {
+	for _, flag := range getAllDockerFlags() {
 		flagNames[flag.FlagName()] = spec.Empty{}
 	}
 	return flagNames


### PR DESCRIPTION
### Describe what this PR does / why we need it
same as [pr](https://github.com/chaosblade-io/chaosblade-operator/pull/148)


### Describe how you did it
Adding flag`container-label-selector` when exec in sidecar;
Adding interface `GetContainerByLabelSelector` to `container.Container` and implement it for docker/containerd runtime;

### Describe how to verify it
Verified by manually e2e testing for scenarios：
1. CPU load with containerd/docker runtime
2. network loss with runtime containerd/docker
