### PR TITLE
drop ioutil package.

### DIFF
--- a/exec/client.go
+++ b/exec/client.go
@@ -18,9 +18,10 @@ package exec
 
 import (
 	"context"
-	"github.com/chaosblade-io/chaosblade-spec-go/log"
-	"io/ioutil"
+	"io"
 	"time"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -44,7 +45,7 @@ func (c *Client) waitAndGetOutput(ctx context.Context, containerId string) (stri
 		return "", err
 	}
 	defer resp.Close()
-	bytes, err := ioutil.ReadAll(resp)
+	bytes, err := io.ReadAll(resp)
 	return string(bytes), err
 }
 
@@ -56,13 +57,13 @@ func containerWait() error {
 	return nil
 }
 
-//GetImageInspectById
+// GetImageInspectById
 func (c *Client) getImageInspectById(imageId string) (types.ImageInspect, error) {
 	inspect, _, err := c.client.ImageInspectWithRaw(context.Background(), imageId)
 	return inspect, err
 }
 
-//DeleteImageByImageId
+// DeleteImageByImageId
 func (c *Client) deleteImageByImageId(imageId string) error {
 	_, err := c.client.ImageRemove(context.Background(), imageId, types.ImageRemoveOptions{
 		Force:         false,

--- a/exec/container/docker/docker.go
+++ b/exec/container/docker/docker.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/log"
@@ -41,7 +41,7 @@ type Client struct {
 	Ctx    context.Context
 }
 
-//GetClient returns the docker client
+// GetClient returns the docker client
 func NewClient(endpoint string) (*Client, error) {
 	var oldClient *client.Client
 	if cli != nil {
@@ -58,7 +58,7 @@ func NewClient(endpoint string) (*Client, error) {
 	return cli, nil
 }
 
-//checkAndCreateClient
+// checkAndCreateClient
 func checkAndCreateClient(endpoint string, cli *client.Client) (*client.Client, error) {
 	if cli == nil {
 		var err error
@@ -119,7 +119,7 @@ func (c *Client) GetContainerById(ctx context.Context, containerId string) (cont
 	return c.GetContainerFromDocker(option)
 }
 
-//getContainerByName returns the container object by container name
+// getContainerByName returns the container object by container name
 func (c *Client) GetContainerByName(ctx context.Context, containerName string) (container.ContainerInfo, error, int32) {
 	option := types.ContainerListOptions{
 		All: true,
@@ -165,7 +165,7 @@ func convertContainerInfo(container2 types.Container) container.ContainerInfo {
 	}
 }
 
-//RemoveContainer
+// RemoveContainer
 func (c *Client) RemoveContainer(ctx context.Context, containerId string, force bool) error {
 	err := c.client.ContainerRemove(context.Background(), containerId, types.ContainerRemoveOptions{
 		Force: force,
@@ -177,7 +177,7 @@ func (c *Client) RemoveContainer(ctx context.Context, containerId string, force 
 	return nil
 }
 
-//ExecuteAndRemove: create and start a container for executing a command, and remove the container
+// ExecuteAndRemove: create and start a container for executing a command, and remove the container
 func (c *Client) ExecuteAndRemove(ctx context.Context, config *containertype.Config, hostConfig *containertype.HostConfig,
 	networkConfig *network.NetworkingConfig, containerName string, removed bool,
 	timeout time.Duration,
@@ -213,7 +213,7 @@ func (c *Client) ExecuteAndRemove(ctx context.Context, config *containertype.Con
 	return containerId, output, nil, spec.OK.Code
 }
 
-//ImageExists
+// ImageExists
 func (c *Client) getImageByRef(ctx context.Context, ref string) (types.ImageSummary, error) {
 	args := filters.NewArgs(filters.Arg("reference", ref))
 	list, err := c.client.ImageList(context.Background(), types.ImageListOptions{
@@ -231,18 +231,18 @@ func (c *Client) getImageByRef(ctx context.Context, ref string) (types.ImageSumm
 	return list[0], nil
 }
 
-//PullImage
+// PullImage
 func (c *Client) pullImage(ref string) (string, error) {
 	reader, err := c.client.ImagePull(context.Background(), ref, types.ImagePullOptions{})
 	if err != nil {
 		return "", err
 	}
 	defer reader.Close()
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := io.ReadAll(reader)
 	return string(bytes), nil
 }
 
-//createAndStartContainer
+// createAndStartContainer
 func (c *Client) createAndStartContainer(ctx context.Context, config *containertype.Config, hostConfig *containertype.HostConfig,
 	networkConfig *network.NetworkingConfig, containerName string) (string, error) {
 	body, err := c.client.ContainerCreate(context.Background(), config, hostConfig, networkConfig, containerName)
@@ -255,7 +255,7 @@ func (c *Client) createAndStartContainer(ctx context.Context, config *containert
 	return containerId, err
 }
 
-//startContainer
+// startContainer
 func (c *Client) startContainer(ctx context.Context, containerId string) error {
 	err := c.client.ContainerStart(context.Background(), containerId, types.ContainerStartOptions{})
 	if err != nil {

--- a/exec/executor_common_linux.go
+++ b/exec/executor_common_linux.go
@@ -17,244 +17,245 @@
 package exec
 
 import (
-    "context"
-    "fmt"
-    osexec "github.com/chaosblade-io/chaosblade-exec-os/exec"
-    "github.com/chaosblade-io/chaosblade-exec-os/exec/model"
-    "github.com/chaosblade-io/chaosblade-spec-go/log"
-    "github.com/chaosblade-io/chaosblade-spec-go/spec"
-    "github.com/chaosblade-io/chaosblade-spec-go/util"
-    "github.com/containerd/cgroups"
-    "io/ioutil"
-    "os"
-    "os/exec"
-    "path"
-    "strings"
-    "syscall"
-    "time"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"syscall"
+	"time"
+
+	osexec "github.com/chaosblade-io/chaosblade-exec-os/exec"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/model"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/containerd/cgroups"
 )
 
 // CommonExecutor is an executor implementation which used copy chaosblade tool to the target container and executed
 type CommonExecutor struct {
-    BaseClientExecutor
+	BaseClientExecutor
 }
 
 func NewCommonExecutor() *CommonExecutor {
-    return &CommonExecutor{
-        BaseClientExecutor{
-            CommandFunc: CommonFunc,
-        },
-    }
+	return &CommonExecutor{
+		BaseClientExecutor{
+			CommandFunc: CommonFunc,
+		},
+	}
 }
 
 func (r *CommonExecutor) Name() string {
-    return "CommonExecutor"
+	return "CommonExecutor"
 }
 
 func (r *CommonExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
-    if err := r.SetClient(expModel); err != nil {
-        log.Errorf(ctx, spec.ContainerExecFailed.Sprintf("GetClient", err))
-        return spec.ResponseFailWithFlags(spec.ContainerExecFailed, "GetClient", err)
-    }
-    containerId := expModel.ActionFlags[ContainerIdFlag.Name]
-    containerName := expModel.ActionFlags[ContainerNameFlag.Name]
-    containerLabelSelector := parseContainerLabelSelector(expModel.ActionFlags[ContainerLabelSelectorFlag.Name])
-    container, response := GetContainer(ctx, r.Client, uid, containerId, containerName, containerLabelSelector)
-    if !response.Success {
-        return response
-    }
-    pid, err, code := r.Client.GetPidById(ctx, container.ContainerId)
-    if err != nil {
-        log.Errorf(ctx, err.Error())
-        return spec.ResponseFail(code, err.Error(), nil)
-    }
+	if err := r.SetClient(expModel); err != nil {
+		log.Errorf(ctx, spec.ContainerExecFailed.Sprintf("GetClient", err))
+		return spec.ResponseFailWithFlags(spec.ContainerExecFailed, "GetClient", err)
+	}
+	containerId := expModel.ActionFlags[ContainerIdFlag.Name]
+	containerName := expModel.ActionFlags[ContainerNameFlag.Name]
+	containerLabelSelector := parseContainerLabelSelector(expModel.ActionFlags[ContainerLabelSelectorFlag.Name])
+	container, response := GetContainer(ctx, r.Client, uid, containerId, containerName, containerLabelSelector)
+	if !response.Success {
+		return response
+	}
+	pid, err, code := r.Client.GetPidById(ctx, container.ContainerId)
+	if err != nil {
+		log.Errorf(ctx, err.Error())
+		return spec.ResponseFail(code, err.Error(), nil)
+	}
 
-    var args string
-    var flags string
+	var args string
+	var flags string
 
-    nsFlags := GetNSExecFlags()
-    m := make(map[string]string, len(nsFlags))
-    for _, f := range nsFlags {
-        m[f.FlagName()] = f.FlagName()
-    }
+	nsFlags := GetNSExecFlags()
+	m := make(map[string]string, len(nsFlags))
+	for _, f := range nsFlags {
+		m[f.FlagName()] = f.FlagName()
+	}
 
-    cgroupRoot := os.Getenv("CGROUP_ROOT")
-    if cgroupRoot != "" && expModel.ActionProcessHang {
-        expModel.ActionFlags["cgroup-root"] = cgroupRoot
-    }
+	cgroupRoot := os.Getenv("CGROUP_ROOT")
+	if cgroupRoot != "" && expModel.ActionProcessHang {
+		expModel.ActionFlags["cgroup-root"] = cgroupRoot
+	}
 
-    for k, v := range expModel.ActionFlags {
-        if v == "" || m[k] != "" || k == "timeout" {
-            continue
-        }
-        flags = fmt.Sprintf("%s --%s=%s", flags, k, v)
-    }
-    _, isDestroy := spec.IsDestroy(ctx)
+	for k, v := range expModel.ActionFlags {
+		if v == "" || m[k] != "" || k == "timeout" {
+			continue
+		}
+		flags = fmt.Sprintf("%s --%s=%s", flags, k, v)
+	}
+	_, isDestroy := spec.IsDestroy(ctx)
 
-    if isDestroy {
-        args = fmt.Sprintf("%s %s %s%s --uid=%s", spec.Destroy, expModel.Target, expModel.ActionName, flags, uid)
-    } else {
-        args = fmt.Sprintf("%s %s %s%s --uid=%s", spec.Create, expModel.Target, expModel.ActionName, flags, uid)
-    }
+	if isDestroy {
+		args = fmt.Sprintf("%s %s %s%s --uid=%s", spec.Destroy, expModel.Target, expModel.ActionName, flags, uid)
+	} else {
+		args = fmt.Sprintf("%s %s %s%s --uid=%s", spec.Create, expModel.Target, expModel.ActionName, flags, uid)
+	}
 
-    args = fmt.Sprintf("%s %s %s %s %s",
-        args,
-        fmt.Sprintf("--%s=%s", model.ChannelFlag.Name, spec.NSExecBin),
-        fmt.Sprintf("--%s=%d", model.NsTargetFlag.Name, pid),
-        fmt.Sprintf("--%s=%s", model.NsPidFlag.Name, spec.True),
-        fmt.Sprintf("--%s=%s", model.NsMntFlag.Name, spec.True),
-    )
+	args = fmt.Sprintf("%s %s %s %s %s",
+		args,
+		fmt.Sprintf("--%s=%s", model.ChannelFlag.Name, spec.NSExecBin),
+		fmt.Sprintf("--%s=%d", model.NsTargetFlag.Name, pid),
+		fmt.Sprintf("--%s=%s", model.NsPidFlag.Name, spec.True),
+		fmt.Sprintf("--%s=%s", model.NsMntFlag.Name, spec.True),
+	)
 
-    if !isDestroy && expModel.ActionProcessHang {
-        return execForHangAction(uid, ctx, expModel, pid, args)
-    }
+	if !isDestroy && expModel.ActionProcessHang {
+		return execForHangAction(uid, ctx, expModel, pid, args)
+	}
 
-    chaosOsBin := path.Join(util.GetProgramPath(), spec.BinPath, spec.ChaosOsBin)
-    argsArray := strings.Split(args, " ")
+	chaosOsBin := path.Join(util.GetProgramPath(), spec.BinPath, spec.ChaosOsBin)
+	argsArray := strings.Split(args, " ")
 
-    command := exec.CommandContext(ctx, chaosOsBin, argsArray...)
-    output, err := command.CombinedOutput()
-    outMsg := string(output)
-    log.Debugf(ctx, "Command Result, output: %v, err: %v", outMsg, err)
-    if err != nil {
-        return spec.ReturnFail(spec.OsCmdExecFailed, fmt.Sprintf("command exec failed, %s", err.Error()))
-    }
-    return spec.Decode(outMsg, nil)
+	command := exec.CommandContext(ctx, chaosOsBin, argsArray...)
+	output, err := command.CombinedOutput()
+	outMsg := string(output)
+	log.Debugf(ctx, "Command Result, output: %v, err: %v", outMsg, err)
+	if err != nil {
+		return spec.ReturnFail(spec.OsCmdExecFailed, fmt.Sprintf("command exec failed, %s", err.Error()))
+	}
+	return spec.Decode(outMsg, nil)
 }
 
 func (r *CommonExecutor) SetChannel(channel spec.Channel) {
 }
 
 func (r *CommonExecutor) DeployChaosBlade(ctx context.Context, containerId string,
-        srcFile, extractDirName string, override bool) error {
-    return nil
+	srcFile, extractDirName string, override bool) error {
+	return nil
 }
 
 func execForHangAction(uid string, ctx context.Context, expModel *spec.ExpModel, pid int32, args string) *spec.Response {
 
-    chaosOsBin := path.Join(util.GetProgramPath(), spec.BinPath, spec.ChaosOsBin)
+	chaosOsBin := path.Join(util.GetProgramPath(), spec.BinPath, spec.ChaosOsBin)
 
-    args = fmt.Sprintf("-s -t %d -p -n -- %s %s", pid, chaosOsBin, args)
+	args = fmt.Sprintf("-s -t %d -p -n -- %s %s", pid, chaosOsBin, args)
 
-    argsArray := strings.Split(args, " ")
+	argsArray := strings.Split(args, " ")
 
-    bin := path.Join(util.GetProgramPath(), spec.BinPath, spec.NSExecBin)
-    log.Debugf(ctx, "run command, %s %s", bin, args)
+	bin := path.Join(util.GetProgramPath(), spec.BinPath, spec.NSExecBin)
+	log.Debugf(ctx, "run command, %s %s", bin, args)
 
-    command := exec.CommandContext(ctx, bin, argsArray...)
-    command.SysProcAttr = &syscall.SysProcAttr{}
+	command := exec.CommandContext(ctx, bin, argsArray...)
+	command.SysProcAttr = &syscall.SysProcAttr{}
 
-    cgroupRoot := os.Getenv("CGROUP_ROOT")
-    if cgroupRoot == "" {
-        cgroupRoot = expModel.ActionFlags["cgroup-root"]
-        if cgroupRoot == "" {
-            cgroupRoot = "/sys/fs/cgroup/"
-        }
-    }
+	cgroupRoot := os.Getenv("CGROUP_ROOT")
+	if cgroupRoot == "" {
+		cgroupRoot = expModel.ActionFlags["cgroup-root"]
+		if cgroupRoot == "" {
+			cgroupRoot = "/sys/fs/cgroup/"
+		}
+	}
 
-    log.Debugf(ctx, "cgroup root path %s", cgroupRoot)
+	log.Debugf(ctx, "cgroup root path %s", cgroupRoot)
 
-    control, err := cgroups.Load(osexec.Hierarchy(cgroupRoot), osexec.PidPath(int(pid)))
-    if err != nil {
-        sprintf := fmt.Sprintf("cgroups load failed, %s", err.Error())
-        return spec.ReturnFail(spec.OsCmdExecFailed, sprintf)
-    }
+	control, err := cgroups.Load(osexec.Hierarchy(cgroupRoot), osexec.PidPath(int(pid)))
+	if err != nil {
+		sprintf := fmt.Sprintf("cgroups load failed, %s", err.Error())
+		return spec.ReturnFail(spec.OsCmdExecFailed, sprintf)
+	}
 
-    if err := command.Start(); err != nil {
-        sprintf := fmt.Sprintf("command start failed, %s", err.Error())
-        return spec.ReturnFail(spec.OsCmdExecFailed, sprintf)
-    }
+	if err := command.Start(); err != nil {
+		sprintf := fmt.Sprintf("command start failed, %s", err.Error())
+		return spec.ReturnFail(spec.OsCmdExecFailed, sprintf)
+	}
 
-    // add target cgroups
-    if err = control.Add(cgroups.Process{Pid: command.Process.Pid}); err != nil {
-        if err := command.Process.Kill(); err != nil {
-            sprintf := fmt.Sprintf("create experiment failed, %v", err)
-            return spec.ReturnFail(spec.OsCmdExecFailed, sprintf)
-        }
-    }
+	// add target cgroups
+	if err = control.Add(cgroups.Process{Pid: command.Process.Pid}); err != nil {
+		if err := command.Process.Kill(); err != nil {
+			sprintf := fmt.Sprintf("create experiment failed, %v", err)
+			return spec.ReturnFail(spec.OsCmdExecFailed, sprintf)
+		}
+	}
 
-    signal := make(chan bool, 1)
-    go func() {
-        for {
-            if comm, err := getProcessComm(command.Process.Pid); err != nil {
-                log.Errorf(ctx, "get process comm failed, %s", err.Error())
-            } else {
-                if cmdline, err := getProcessCmdline(command.Process.Pid); err != nil {
-                    log.Errorf(ctx, "get process cmdline failed, %s", err.Error())
-                } else {
-                    if cmdline == "" {
-                        log.Errorf(ctx, "unknown err, process exit.")
-                        signal <- true
-                        break
-                    }
-                }
+	signal := make(chan bool, 1)
+	go func() {
+		for {
+			if comm, err := getProcessComm(command.Process.Pid); err != nil {
+				log.Errorf(ctx, "get process comm failed, %s", err.Error())
+			} else {
+				if cmdline, err := getProcessCmdline(command.Process.Pid); err != nil {
+					log.Errorf(ctx, "get process cmdline failed, %s", err.Error())
+				} else {
+					if cmdline == "" {
+						log.Errorf(ctx, "unknown err, process exit.")
+						signal <- true
+						break
+					}
+				}
 
-                log.Infof(ctx, "wait nasexec process pasue, current comm: %s, pid: %d", comm, command.Process.Pid)
-                if comm == "pause\n" {
-                    signal <- true
-                    break
-                }
-            }
-            time.Sleep(time.Millisecond)
-        }
-    }()
+				log.Infof(ctx, "wait nasexec process pasue, current comm: %s, pid: %d", comm, command.Process.Pid)
+				if comm == "pause\n" {
+					signal <- true
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
 
-    if <-signal {
-        for {
-            if err := command.Process.Signal(syscall.SIGCONT); err != nil {
-                sprintf := fmt.Sprintf("send signal failed, %s", err.Error())
-                return spec.ReturnFail(spec.OsCmdExecFailed, sprintf)
-            }
-            time.Sleep(time.Millisecond)
+	if <-signal {
+		for {
+			if err := command.Process.Signal(syscall.SIGCONT); err != nil {
+				sprintf := fmt.Sprintf("send signal failed, %s", err.Error())
+				return spec.ReturnFail(spec.OsCmdExecFailed, sprintf)
+			}
+			time.Sleep(time.Millisecond)
 
-            if comm, err := getProcessComm(command.Process.Pid); err != nil {
-                log.Errorf(ctx, "get process comm failed, %s", err.Error())
-            } else {
-                if cmdline, err := getProcessCmdline(command.Process.Pid); err != nil {
-                    log.Errorf(ctx, "get process cmdline failed, %s", err.Error())
-                } else {
-                    if cmdline == "" {
-                        log.Errorf(ctx, "unknown err, process exit.")
-                        break
-                    }
-                }
+			if comm, err := getProcessComm(command.Process.Pid); err != nil {
+				log.Errorf(ctx, "get process comm failed, %s", err.Error())
+			} else {
+				if cmdline, err := getProcessCmdline(command.Process.Pid); err != nil {
+					log.Errorf(ctx, "get process cmdline failed, %s", err.Error())
+				} else {
+					if cmdline == "" {
+						log.Errorf(ctx, "unknown err, process exit.")
+						break
+					}
+				}
 
-                log.Infof(ctx, "wait nasexec process resume, current comm: %s, pid: %d", comm, command.Process.Pid)
-                if comm == "nsexec\n" {
-                    break
-                }
-            }
-        }
-    }
-    return spec.ReturnSuccess(command.Process.Pid)
+				log.Infof(ctx, "wait nasexec process resume, current comm: %s, pid: %d", comm, command.Process.Pid)
+				if comm == "nsexec\n" {
+					break
+				}
+			}
+		}
+	}
+	return spec.ReturnSuccess(command.Process.Pid)
 }
 
 func getProcessComm(pid int) (string, error) {
-    f, err := os.Open(fmt.Sprintf("%s/%d/comm", "/proc", pid))
-    if err != nil {
-        return "", err
-    }
-    defer f.Close()
+	f, err := os.Open(fmt.Sprintf("%s/%d/comm", "/proc", pid))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
 
-    b, err := ioutil.ReadAll(f)
-    if err != nil {
-        return "", err
-    }
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
 
-    return string(b), nil
+	return string(b), nil
 }
 
 func getProcessCmdline(pid int) (string, error) {
-    f, err := os.Open(fmt.Sprintf("%s/%d/cmdline", "/proc", pid))
-    if err != nil {
-        return "", err
-    }
-    defer f.Close()
+	f, err := os.Open(fmt.Sprintf("%s/%d/cmdline", "/proc", pid))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
 
-    b, err := ioutil.ReadAll(f)
-    if err != nil {
-        return "", err
-    }
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
 
-    return string(b), nil
+	return string(b), nil
 }


### PR DESCRIPTION
/kind cleanup

Drop ioutil package.
As it is deprecation , and can be replaced well.

```
Deprecated: As of Go 1.16, the same functionality is now 
provided by package [io](https://pkg.go.dev/io) 
or package [os](https://pkg.go.dev/os), 
and those implementations should be preferred in new code
```