### PR TITLE
refactor: update Docker client to use API version negotiation instead…

### DIFF
--- a/exec/container/docker/docker.go
+++ b/exec/container/docker/docker.go
@@ -65,9 +65,9 @@ func checkAndCreateClient(endpoint string, cli *client.Client) (*client.Client, 
 	if cli == nil {
 		var err error
 		if endpoint == "" {
-			cli, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.24"))
+			cli, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 		} else {
-			cli, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.24"), client.WithHost(endpoint))
+			cli, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation(), client.WithHost(endpoint))
 		}
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
… of fixed v1.24


fixed the following issue:
Support for docker with version later than 29.0.0 https://github.com/chaosblade-io/chaosblade/issues/1284