### PR TITLE
fix: use API version negotiation instead of hardcoded 1.24 (#1284)

### DIFF
--- a/exec/container/docker/docker.go
+++ b/exec/container/docker/docker.go
@@ -65,9 +65,9 @@ func checkAndCreateClient(endpoint string, cli *client.Client) (*client.Client, 
 	if cli == nil {
 		var err error
 		if endpoint == "" {
-			cli, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.24"))
+			cli, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 		} else {
-			cli, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.24"), client.WithHost(endpoint))
+			cli, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation(), client.WithHost(endpoint))
 		}
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Problem

When using Docker 29.0+ (which removed API version 1.24), ChaosBlade fails to connect to the Docker daemon:

```
unable to connect to docker engine: error during connect: Get "http://d/v1.24/containers/json?filters=...": EOF
```

Fixes: https://github.com/chaosblade-io/chaosblade/issues/1284

## Root Cause

In `exec/container/docker/docker.go`, the Docker client is created with a hardcoded API version:

```go
cli, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.24"))
```

Docker 29.0 (released 2025) removed support for API version 1.24, causing the connection to fail with a 404 error.

The code already had a `ping()` function that attempts version negotiation, but it could never run because the initial connection failed first.

## Fix

Replace `client.WithVersion("1.24")` with `client.WithAPIVersionNegotiation()`:

```go
cli, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
```

This uses the Docker SDK's built-in API version negotiation, which automatically detects and uses the correct API version supported by the Docker daemon.

## Changes

- `exec/container/docker/docker.go`: Use `WithAPIVersionNegotiation()` instead of hardcoded `WithVersion("1.24")`

## Compatibility

This change is backward compatible. The negotiation mechanism works with all Docker versions that support the Docker SDK, including older versions that still support API 1.24.